### PR TITLE
Add 'mailer' module option

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
                     postfix.enable = true;
                     logwatch = {
                       enable = true;
+                      # mailer = "${lib.getExe' pkgs.msmtp "sendmail"} -t";
                       range = "since 24 hours ago for those hours";
                       services = [
                         "All"
@@ -117,6 +118,9 @@
                   server.systemctl("restart logwatch")
                   # VMs on CI runners can be kind of slow, delay here
                   time.sleep(3)
+
+                  cfg = server.succeed("cat $(dirname $(readlink -f $(command -v logwatch)))/../usr/share/logwatch/default.conf/logwatch.conf")
+                  print(cfg)
 
                   # Get all mails for root and check if the expected data is there
                   mail = server.succeed("mail -p")

--- a/modules/logwatch.nix
+++ b/modules/logwatch.nix
@@ -12,6 +12,7 @@ let
 
   packageConfig = {
     inherit (cfg)
+      mailer
       archives
       mailto
       mailfrom
@@ -69,6 +70,15 @@ in
         The delay will be chosen between zero and this value.
         This value must be a time span in the format specified by
         {manpage}`systemd.time(7)`
+      '';
+    };
+
+    mailer = lib.mkOption {
+      default = "${lib.getExe' pkgs.postfix "sendmail"} -t";
+      type = types.singleLineStr;
+      example = lib.literalExpression "${lib.getExe' pkgs.msmtp "sendmail"} -t";
+      description = ''
+        Set the 'mailer' command to be used by logwatch.
       '';
     };
 

--- a/packages/logwatch.nix
+++ b/packages/logwatch.nix
@@ -48,9 +48,12 @@ let
 
   mkConf =
     c:
+    let
+      mailer = if (c.mailer or "") != "" then c.mailer else (lib.getExe' postfix "sendmail") + " -t";
+    in
     ''
       TmpDir = /tmp
-      mailer = "${lib.getExe' postfix "sendmail"} -t"
+      mailer = ${mailer}
       Archives = ${if c.archives or true then "Yes" else "No"}
       MailTo = ${c.mailto or "root"}
       MailFrom = ${c.mailfrom or "Logwatch"}


### PR DESCRIPTION
This can be used to change the default `postfix` mailer without resorting to random code in `extraFixup`.

Note that this code is not (yet) exercised in the default flake check.