### PR TITLE
Add 'format' module option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Available options:
   * `mailfrom`: Name of the sender of the reports. Defaults to `"Logwatch"`.
   * `range`: Date range: Yesterday, Today, All, Help where help will describe additional options. Defaults to `"Yesterday"`.
   * `detail`: Report Detail Level - High, Med, Low or any #. Defaults to `"Low"`.
+  * `format`: Report format - text or html. Defaults to `"text"`.
   * `services`: Which services to digest, by name. Defaults to `[ "All" ]`.
 
 * Additional logwatch configuration options:

--- a/modules/logwatch.nix
+++ b/modules/logwatch.nix
@@ -18,6 +18,7 @@ let
       mailfrom
       range
       detail
+      format
       services
       ;
   };
@@ -129,6 +130,11 @@ in
       default = "Low";
       type = types.singleLineStr;
       description = "Detail level of the analysis";
+    };
+    format = lib.mkOption {
+      default = "text";
+      type = types.singleLineStr;
+      description = "Format of the report";
     };
     services = lib.mkOption {
       default = [ "All" ];

--- a/packages/logwatch/package.nix
+++ b/packages/logwatch/package.nix
@@ -66,6 +66,7 @@ let
         ${lib.optionalString (config.mailfrom != null) "MailFrom = ${config.mailfrom}"}
         ${lib.optionalString (config.range != null) "Range = ${config.range}"}
         ${lib.optionalString (config.detail != null) "Detail = ${config.detail}"}
+        ${lib.optionalString (config.format != null) "Format = ${config.format}"}
       ''
       + lib.concatMapStrings (s: "Service = ${s}\n") (config.services or [ ])
     );


### PR DESCRIPTION
Hi @SFrijters. I had previously been using `extraFixup` to add a config line specifying that my logwatch mails should be HTML rather than text. Since your recent changes to clean that up and move to `customServices`, I've added a first-class option to allow formatting to be configured directly. I hope this might be useful for other users of your flake.

Many thanks for your work on this, it's much appreciated.